### PR TITLE
Update warehouse-picking-by-fefo.md

### DIFF
--- a/business-central/warehouse-picking-by-fefo.md
+++ b/business-central/warehouse-picking-by-fefo.md
@@ -19,7 +19,7 @@ First-Expired-First-Out (FEFO) is a sorting method that ensures that the oldest 
  This functionality only works when the following criteria are met:  
 
 -   The item must have a serial/lot number.  
--   On the item’s item tracking code setup, the **SN Specific Tracking** field or the **Lot Specific Tracking** field must be selected.  
+-   On the item’s item tracking code setup, the **SN Warehouse Tracking** field or the **Lot Warehouse Tracking** field must be selected.  
 -   The item must be posted to inventory with an expiration date.  
 -   On the location card, the **Require Pick** check box must be selected.  
 -   On the location card, the **Pick According to FEFO** check box must be selected.  


### PR DESCRIPTION
We do not change the code for years, Item Tracking Code page has 'Lot (SN) Specific Tracking' and 'Lot (SN) Warehouse Tracking' checkers.
We need to set both checkers for use 'Picking According to FEFO' feature. We cannot set 'Lot (SN) Warehouse Tracking' without active 'Lot (SN) Specific Tracking'. I think enough to show in help one ('Warehouse' checker key point in this story) checker only: Lot (SN) Warehouse Tracking.

P.S.
The example for use the 'light' location and 'Picking According to FEFO' feature - [[INFO] How to setup the simple location that allow to user work with Bins, Lots, Expiration Dates on Inventory Put-away/Pick and use automatic Pick According to FEFO process](https://community.dynamics.com/business/f/dynamics-365-business-central-forum/378938/info-how-to-setup-the-simple-location-that-allow-to-user-work-with-bins-lots-expiration-dates-on-inventory-put-away-pick-and-use-automatic-pick-according-to-fefo-process). Even in such case we use Warehouse Entry and need to set 'Warehouse' checker.