### PR TITLE
A note about user restrictions of viewing posted documents with RC was changed

### DIFF
--- a/business-central/inventory-responsibility-centers.md
+++ b/business-central/inventory-responsibility-centers.md
@@ -49,7 +49,7 @@ To set this up, you assign responsibility centers to users in three functional a
 5. In the **Service Resp. Ctr. Filter** field, enter the responsibility center where the user will have tasks related to service management.  
 
 > [!NOTE]  
-> Users will still be able to view all posted documents and ledger entries, not just those related to their own responsibility center.
+> Users will only be able to view posted documents related to their own responsibility center, but they will still be able to view all ledger entries.
 
 ## See Also
 


### PR DESCRIPTION
In 2010 it was prohibited for a user to view any posted document that is not related to user's responsibility center. This restriction is still actual, so the note must be changed to match the current behaviour.
However, it is still possible for a user to view all Customer/Vendor Ledger Entries.

I checked the behaviour on Business Central Spring Release and Business Central Wave 2 2020.

Feel free to suggest any changes if my change does not correspond with the documentation style etc.