### PR TITLE
Fix typo `D365 EXTENSION MGMT` -> `D365 EXTENSION MGT`

### DIFF
--- a/business-central/ui-extensions-install-uninstall.md
+++ b/business-central/ui-extensions-install-uninstall.md
@@ -19,7 +19,7 @@ ms.author: solsen
 You can change [!INCLUDE[prod_short](includes/prod_short.md)] by installing extensions that, for example, add functionality, changes behavior, or gives you access to new online services. For more information, see [Customizing Business Central Using Extensions](ui-extensions.md).
 
 > [!NOTE]
-> To install extensions from AppSource or add per-tenant extensions, you must have the right permissions. You must either be a member of the D365 EXTENSION MGMT user group or you must have the D365 EXTENSION MGMT permission set. If you are an administrator, you can assign user groups and permissions to other users in your company.<br /><br />
+> To install extensions from AppSource or add per-tenant extensions, you must have the right permissions. You must either be a member of the D365 EXTENSION MGT user group or you must have the D365 EXTENSION MGT permission set. If you are an administrator, you can assign user groups and permissions to other users in your company.<br /><br />
 To use the functionality that is provided by an extension, such as opening pages, running reports, selecting actions, and so on, you must be assigned the permission sets that are installed as part of the extension.
 
 ## Installing an Extension

--- a/business-central/ui-extensions.md
+++ b/business-central/ui-extensions.md
@@ -15,7 +15,7 @@ ms.author: edupont
 You can change [!INCLUDE[prod_short](includes/prod_short.md)] by installing extensions that add functionality, changes behavior, or gives you access to new online services, for example.
 
 > [!NOTE]
-> To install extensions from AppSource or add per-tenant extensions, you must have the right permissions. You must either be a member of the D365 EXTENSION MGMT user group or you must have the D365 EXTENSION MGMT permission set. If you are an administrator, you can assign user groups and permissions to other users in your company.
+> To install extensions from AppSource or add per-tenant extensions, you must have the right permissions. You must either be a member of the D365 EXTENSION MGT user group or you must have the D365 EXTENSION MGT permission set. If you are an administrator, you can assign user groups and permissions to other users in your company.
 
 To use the functionality that is provided by an extension, such as opening pages, running reports, selecting actions, and so on, you must be assigned the permission sets that are installed as part of the extension.
 


### PR DESCRIPTION
Source: https://docs.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/devenv-get-started#controlling-user-access-to-developing-and-publishing-extensions