### PR TITLE
Restore function is related to sales, not purchase

### DIFF
--- a/business-central/across-how-to-archive-documents.md
+++ b/business-central/across-how-to-archive-documents.md
@@ -16,7 +16,7 @@
 # Archive Documents
 You can archive sales and purchase orders, quotes, return orders, and blanket orders, for example because you want to save a copy of a document for reuse later. You can archive a sales or purchase document several times, saving a different archived version each time.
 
-For archived documents where the original still exists and is not posted, you can use the **Restore** function to overwrite the original with the archived version of the document. This is practical if you need to restore the contents of a document to an earlier state.
+For archived SALES documents where the original still exists and is not posted, you can use the **Restore** function to overwrite the original with the archived version of the document. This is practical if you need to restore the contents of a document to an earlier state.
 
 For archived documents where the original is deleted, you can only reuse the content by copying the data, for example with the **Copy from Document** function.  
 

--- a/business-central/across-how-to-archive-documents.md
+++ b/business-central/across-how-to-archive-documents.md
@@ -16,7 +16,7 @@
 # Archive Documents
 You can archive sales and purchase orders, quotes, return orders, and blanket orders, for example because you want to save a copy of a document for reuse later. You can archive a sales or purchase document several times, saving a different archived version each time.
 
-For archived SALES documents where the original still exists and is not posted, you can use the **Restore** function to overwrite the original with the archived version of the document. This is practical if you need to restore the contents of a document to an earlier state.
+For archived sales documents where the original still exists and is not posted, you can use the **Restore** function to overwrite the original with the archived version of the document. This is practical if you need to restore the contents of a document to an earlier state.
 
 For archived documents where the original is deleted, you can only reuse the content by copying the data, for example with the **Copy from Document** function.  
 


### PR DESCRIPTION
Restore function is only related to sales side. It should be clarified here:
For archived SALES documents where the original still exists and is not posted, you can use the **Restore** function to overwrite the original with the archived version of the document. This is practical if you need to restore the contents of a document to an earlier state.