### PR TITLE
Fix for TIP and NOTE formatting issue

### DIFF
--- a/business-central/sales-how-record-sales-price-discount-payment-agreements.md
+++ b/business-central/sales-how-record-sales-price-discount-payment-agreements.md
@@ -216,10 +216,12 @@ These steps differ, depending on whether your administrator has turned on the **
 5. In the **Defines** field, choose either **Price & Discount**, or just **Discount**. 
 6. In the **Line Discount %** field, specify the discount percentage.
 
-    > [!TIP]
-    > You can filter the lines by choosing the appropriate option in the **View Columns for** field.
-    > [!NOTE]  
-    > Invoice discount codes are represented by existing customer cards. Using customer names as codes enables you to quickly assign invoice discount terms to customers by picking the name of another customer who will have the same terms. To set up customer-specific invoice discount terms, set the **Invoice Disc. Code** field to the customer's customer code, and then proceed to the next step.
+> [!TIP]
+> You can filter the lines by choosing the appropriate option in the **View Columns for** field.
+
+> [!NOTE]  
+> Invoice discount codes are represented by existing customer cards. Using customer names as codes enables you to quickly assign invoice discount terms to customers by picking the name of another customer who will have the same terms. To set up customer-specific invoice discount terms, set the **Invoice Disc. Code** field to the customer's customer code, and then proceed to the next step.
+
 ---
 
 ## To set up an invoice discount for a customer


### PR DESCRIPTION
Added a new line between the TIP and NOTE to attempt to fix the formatting issue that's currently resulting in the NOTE text showing as a section heading.
![image](https://user-images.githubusercontent.com/14233842/142851483-aaf28eb7-60ab-40c2-af96-6774e11543c5.png)
