### PR TITLE
Customers launching a trial focus on Dynamics 365 Business Central an…

### DIFF
--- a/business-central/includes/beethoven-trial.md
+++ b/business-central/includes/beethoven-trial.md
@@ -20,6 +20,9 @@ This app is a cloud-based service that doesn't require special software other th
 
 You can't. Use a work or school email address.
 
+> [!NOTE]
+> Remember that [!INCLUDE [prod_short](includes/prod_short.md)] is always associated with some Microsoft 365 tenant. This way, [!INCLUDE [prod_short](includes/prod_short.md)] can recognize other applications available on your tenant, like Power BI, Excel, or Outlook, and integrate with them.
+
 ### Can I sign up for other Dynamics 365 apps such as Sales, Marketing, and Customer Service?
 
 Yes, you can. To view all available trials, [visit the trial hub page](https://www.microsoft.com/dynamics-365/free-trial). You can use the same email account to sign up for different trials.<!-- However, it is not possible to have multiple apps on the same trial site. Each trial will be on a different org and URL. The trial data won’t be shared across apps.-->

--- a/business-central/includes/beethoven-trial.md
+++ b/business-central/includes/beethoven-trial.md
@@ -20,8 +20,8 @@ This app is a cloud-based service that doesn't require special software other th
 
 You can't. Use a work or school email address.
 
-> [!NOTE]
-> Remember that [!INCLUDE [prod_short](includes/prod_short.md)] is always associated with some Microsoft 365 tenant. This way, [!INCLUDE [prod_short](includes/prod_short.md)] can recognize other applications available on your tenant, like Power BI, Excel, or Outlook, and integrate with them.
+> [!TIP]
+> [!INCLUDE [prod_short](prod_short.md)] is always associated with some Microsoft 365 tenant. This way, [!INCLUDE [prod_short](prod_short.md)] can recognize other applications available on your tenant, like Power BI, Excel, or Outlook, and integrate with them.
 
 ### Can I sign up for other Dynamics 365 apps such as Sales, Marketing, and Customer Service?
 


### PR DESCRIPTION
…d do not think about its integration with the ecosystem. Explaining why the correct tenant is so important at this step is crucial.

I checked [!INCLUDE beethoven-trial]. Only the Trial FAQ https://learn.microsoft.com/en-us/dynamics365/business-central/trial-faq use this !INCLUDE. In my opinion, more details about the tenant would fit well in the context of this site.