### PR TITLE
Normalize INCLUDE syntax in about-export-data.md

### DIFF
--- a/business-central/about-export-data.md
+++ b/business-central/about-export-data.md
@@ -12,7 +12,7 @@ ms.service: dynamics-365-business-central
 ---
 # Export your business data to Excel
 
-Excel is a powerful tool to work with data. From inside [!INCLUDE[prod_short](includes/prod_short.md)], you can open any list in Excel. You can even modify data in Excel and then submit it back to [!INCLUDE [prod_short](includes/prod_short.md)]. The same capability makes it easy for you to take your data with you if you decide to cancel your subscription.
+Excel is a powerful tool to work with data. From inside [!INCLUDE[prod_short](includes/prod_short.md)], you can open any list in Excel. You can even modify data in Excel and then submit it back to [!INCLUDE[prod_short](includes/prod_short.md)]. The same capability makes it easy for you to take your data with you if you decide to cancel your subscription.
 
 ## Opening and exporting lists in Excel
 


### PR DESCRIPTION
## What

Removes a single space in one INCLUDE macro occurrence in `business-central/about-export-data.md` to match the file's own prevailing style.

## Why

The file has 7 occurrences of the DocFX `[!INCLUDE[...]]` macro referencing `prod_short`. Six use the no-space form (`[!INCLUDE[prod_short](includes/prod_short.md)]`); one in the opening paragraph uses the space form (`[!INCLUDE [prod_short](includes/prod_short.md)]`). This PR removes the outlier space so all seven occurrences in this file are written identically.

## Scope

- One file: `business-central/about-export-data.md`
- One-character edit: delete the space between `INCLUDE` and `[prod_short]`
- No semantic change; DocFX renders both forms identically
- No other files touched

## Verification

`git diff --numstat` on the change:

```
1	1	business-central/about-export-data.md
```

Happy to adjust if the space form is the house style and the no-space majority in this file is the anomaly — let me know and I'll invert the direction.
