### PR TITLE
Add Test Connection step and HttpClient Requests troubleshooting to Ideal Postcodes setup [UK]

### DIFF
--- a/business-central/LocalFunctionality/UnitedKingdom/ui-extensions-setup-idealpostcodes-service.md
+++ b/business-central/LocalFunctionality/UnitedKingdom/ui-extensions-setup-idealpostcodes-service.md
@@ -39,6 +39,10 @@ To learn more about Ideal Postcodes, visit their [website](https://ideal-postcod
    1. In the **API Key** field, enter the API key.
    1. Read the **Terms & Conditions**.
    1. Select the **Enabled** checkbox, and then choose **OK**.
+   1. Choose **Actions**, and then **Test Connection**. You should see *Connection test was successful*.
+
+      > [!IMPORTANT]
+      > If the test returns *Connection test failed. Received response 0*, the extension isn't allowed to make outbound HTTP calls. To fix, search for **Extension Management**, select the **IdealPostcodes** extension, and turn on **Allow HttpClient Requests**. Then try **Test Connection** again.
 
 1. On the **Service Connections** page, verify that the **Address Provider** field contains **Ideal Postcodes**. If it does, the service is ready to use.
 

--- a/business-central/LocalFunctionality/UnitedKingdom/ui-extensions-setup-idealpostcodes-service.md
+++ b/business-central/LocalFunctionality/UnitedKingdom/ui-extensions-setup-idealpostcodes-service.md
@@ -39,10 +39,10 @@ To learn more about Ideal Postcodes, visit their [website](https://ideal-postcod
    1. In the **API Key** field, enter the API key.
    1. Read the **Terms & Conditions**.
    1. Select the **Enabled** checkbox, and then choose **OK**.
-   1. Choose **Actions**, and then **Test Connection**. You should see *Connection test was successful*.
+   1. Choose **Actions**, and then **Test Connection**. If the test was successful, the *Connection test was successful* message displays.
 
       > [!IMPORTANT]
-      > If the test returns *Connection test failed. Received response 0*, the extension isn't allowed to make outbound HTTP calls. To fix, search for **Extension Management**, select the **IdealPostcodes** extension, and turn on **Allow HttpClient Requests**. Then try **Test Connection** again.
+      > If the *Connection test failed. Received response 0* message displays, the extension isn't allowed to make outbound HTTP calls. To fix the issue, search for **Extension Management**, select the **IdealPostcodes** extension, and turn on the **Allow HttpClient Requests** toggle. Then, test the connection again.
 
 1. On the **Service Connections** page, verify that the **Address Provider** field contains **Ideal Postcodes**. If it does, the service is ready to use.
 


### PR DESCRIPTION
Adds two items based on multiple customer support reports during first install:

1. **Test Connection step** — the Ideal Postcodes Provider Setup page has an **Actions → Test Connection** action that validates the API key in one click. Currently undocumented, so admins finish setup and only discover problems later on a real lookup.

2. **"Received response 0" troubleshooting callout** — most common first-install failure. Resolved by enabling **Allow HttpClient Requests** for the IdealPostcodes extension in **Extension Management**.