### PR TITLE
Fix Russia localization: replace obsolete Departments nav with Tell Me search

### DIFF
--- a/business-central/LocalFunctionality/Russia/Absence-registration.md
+++ b/business-central/LocalFunctionality/Russia/Absence-registration.md
@@ -23,7 +23,7 @@ There are four types of orders in [!INCLUDE[prod_short](../../includes/prod_shor
 
 All types of orders are issued in a similar way.
 
-1. Go to **Departments > Human resources > Absence Orders**
+1. Choose the ![Tell Me feature](../../media/ui-search/search_small.png "Tell me what you want to do") icon, enter **Absence Orders**, and then choose the related link.
 1. Fill the header of order:
 
    | Field | Description |

--- a/business-central/LocalFunctionality/Russia/Currency-information-Import-currency-rates.md
+++ b/business-central/LocalFunctionality/Russia/Currency-information-Import-currency-rates.md
@@ -38,7 +38,7 @@ Go to **Currency**. Оn the **General tab** fill fields for each currency:
 
 ### Import currency rates
 
-1. Go to **Departments** > **Financial management** > **Periodic activities** > **Currency** > **Import currency rates**.
+1. Choose the ![Tell Me feature](../../media/ui-search/search_small.png "Tell me what you want to do") icon, enter **Import currency rates**, and then choose the related link.
 1. Enter the start and end dates of the period for which you want to adjust the exchange rates.
 
 ## Related information

--- a/business-central/LocalFunctionality/Russia/Sale-of-fixed-assets.md
+++ b/business-central/LocalFunctionality/Russia/Sale-of-fixed-assets.md
@@ -16,7 +16,7 @@ A sale or transfer of a fixed asset consists of two stages.
 
 ## Stage 1: Depreciation of fixed assets
 
-1. Go to **Departments** > **Financial management** > **Fixed Assets** > **FA G/L Journals**.
+1. Choose the ![Tell Me feature](../../media/ui-search/search_small.png "Tell me what you want to do") icon, enter **Fixed Asset G/L Journals**, and then choose the related link.
 1. Fill the journal lines:
 
    | Field | Description |
@@ -25,7 +25,7 @@ A sale or transfer of a fixed asset consists of two stages.
    | Account Type | Fixed Asset |
    | Account No. | Fixed asset code to be depreciate |
    | Depreciation Book Code | Specifies the code for the depreciation book to which the line is posted |
-   | FA Posting Type | Depriciation |
+   | FA Posting Type | Depreciation |
    | Amount | not fill |
    | Bal. Account Type | G/L Account |
    | Bal.Account No. | G/L Account for expenses related to the sale of fixed assets |
@@ -33,7 +33,7 @@ A sale or transfer of a fixed asset consists of two stages.
 
 ## Stage 2: Sale of fixed assets by the sales accounts
 
-1. Go to **Financial management** > **Receivables** > **Invoices**
+1. Choose the ![Tell Me feature](../../media/ui-search/search_small.png "Tell me what you want to do") icon, enter **Sales Invoices**, and then choose the related link.
 1. The fields in the document header are filled in the same way as the sales order fields.
 1. Fill the lines:
 

--- a/business-central/LocalFunctionality/Russia/upload-books-purchases-sales-xml-vat-declaration.md
+++ b/business-central/LocalFunctionality/Russia/upload-books-purchases-sales-xml-vat-declaration.md
@@ -50,7 +50,7 @@ The system generates an XML file in the folder specified in the settings and fil
 
 ## Uploading VAT declaration to XML
 
-To generate a Declaration file, go to **Departments -> VAT Declaration -> Export VAT Declaration to XML**:
+To generate a Declaration file, choose the ![Tell Me feature](../../media/ui-search/search_small.png "Tell me what you want to do") icon, enter **Export VAT Declaration to XML**, and then choose the related link:
 
 To calculate and upload a file, you must specify:
 


### PR DESCRIPTION
## Summary
Replace obsolete Departments menu navigation with the modern Tell Me (search) pattern in 4 Russia localization docs.

## Problem
The Departments menu was removed in Business Central 2019 (v14+). These Russia localization docs still instructed users to navigate via `Departments > ... > Page`, which no longer exists in any supported BC version.

## Fix
Replaced all 5 stale navigation paths with the standard Tell Me search pattern already used throughout adjacent Russia localization docs (e.g., `how-to-create-cash-account-cards.md`, `how-to-set-up-customer-prepayments.md`).

Also fixed in Sale-of-fixed-assets.md:
- Typo: Depriciation -> Depreciation
- "FA G/L Journals" updated to correct full caption "Fixed Asset G/L Journals"
  - Source proof: BusinessCentralApps\App\Layers\W1\BaseApp\FixedAssets\FixedAsset\FixedAssetGLJournal.Page.al:23 -- Caption = 'Fixed Asset G/L Journals'

## Files changed
| File | Change |
|------|--------|
| Absence-registration.md | `Departments > Human resources > Absence Orders` -> Tell Me search |
| Currency-information-Import-currency-rates.md | `Departments > Financial management > ... > Import currency rates` -> Tell Me search |
| Sale-of-fixed-assets.md | Two stale nav paths -> Tell Me search; typo fix; correct FA journal caption |
| upload-books-purchases-sales-xml-vat-declaration.md | `Departments -> VAT Declaration -> Export VAT Declaration to XML` -> Tell Me search |
