### PR TITLE
Remove double-word typos across 14 files

### DIFF
--- a/business-central/LocalFunctionality/India/FA_Depreciation.md
+++ b/business-central/LocalFunctionality/India/FA_Depreciation.md
@@ -52,8 +52,8 @@ Shift depreciation is used when manufacturing companies have multiple production
     |**Depreciation Ending Date**|Specifies the ending date of depreciation.|
     |**No. of Depreciation Years**|Specifies the no. of years of depreciation.|
     |**Depreciation Method**|Specifies the depreciation calculation method.|
-    |**Straight Line %**|Specifies the the Straight Line % if the depreciation method is selected as straight line.|
-    |**Declining-Balance %**|Specifies the the Declining-Balance % if the depreciation method is selected as straight line.|
+    |**Straight Line %**|Specifies the Straight Line % if the depreciation method is selected as straight line.|
+        |**Declining-Balance %**|Specifies the Declining-Balance % if the depreciation method is selected as straight line.|
     |**Shift Type**|Specifies the shift type, for example Single, Double, Triple.|
     |**Industry Type**|Specifies the industry type, for example Normal, Seasonal, Non-Seasonal.|
     |**Used No. of Days**|Specifies the used number of days.|

--- a/business-central/LocalFunctionality/UnitedStates/set-up-use-irs1099-form-v24.md
+++ b/business-central/LocalFunctionality/UnitedStates/set-up-use-irs1099-form-v24.md
@@ -37,7 +37,7 @@ To use 1099 forms in [!INCLUDE [prod_short](../../includes/prod_short.md)], you 
 1. To collect details from vendor ledger entries, such as amounts, from the **IRS 1099 Form Doc Line Details** page for each calculated amount on the IRS 1099 form document, turn on the **Collect Details For Line** toggle.
 
    > [!NOTE]
-   > Collecting details about vendor ledger entries is helpful for reviewing amounts, but it can take up space in your database. If you don't turn on the toggle, the total amount is calculated without listing each amount from the the vendor ledger entries.
+   > Collecting details about vendor ledger entries is helpful for reviewing amounts, but it can take up space in your database. If you don't turn on the toggle, the total amount is calculated without listing each amount from the vendor ledger entries.
 
 1. Optionally, in the **Protect TIN** field, specify whether to mask the taxpayer identification number (TIN) for vendors, or for both vendors and your company. You can also choose not to protect TIN numbers.
 

--- a/business-central/SRB/working-with-contracts/customer-contracts.md
+++ b/business-central/SRB/working-with-contracts/customer-contracts.md
@@ -24,7 +24,7 @@ On the **Shipping and Billing** FastTab, you can specify ship-to and bill-to rec
    Similar to sales orders, a deviating invoice recipient can be entered here. This is taken into account when creating the contract invoices.
 
 > [!NOTE]
-> Contracts are available in the **Sell-to Customer Sales History** FactBox on the the **Customer Card**, **Vendor Card**, and **Contact Card** pages. Choose the respective cue to open an overview.
+> Contracts are available in the **Sell-to Customer Sales History** FactBox on the **Customer Card**, **Vendor Card**, and **Contact Card** pages. Choose the respective cue to open an overview.
 
 ## Overview of the process for creating a customer subscription contract
 

--- a/business-central/admin-users-profiles-roles.md
+++ b/business-central/admin-users-profiles-roles.md
@@ -126,7 +126,7 @@ You can delete a profile by choosing the **Delete** action on the **Profiles (Ro
 
 ### Delete all personalizations made by a specific user
 
-You can delete all changes that a user makes to any pages, which reverts the pages to the the original layout. Personalizations aren't associated with a profile (role). If a user personalizes a page, they experience the personalizations on the page no matter which role they're using.
+You can delete all changes that a user makes to any pages, which reverts the pages to the original layout. Personalizations aren't associated with a profile (role). If a user personalizes a page, they experience the personalizations on the page no matter which role they're using.
 
 1. [!INCLUDE[open-search](includes/open-search.md)], enter **User Settings**, and then select the related link.
 

--- a/business-central/finance-sustainability-setup.md
+++ b/business-central/finance-sustainability-setup.md
@@ -39,7 +39,7 @@ To configure these settings, follow these steps:
     | Field | Description |
     |-------|-------------|
     | **Emission Unit of Measure Code** | Enter the unit of measure code that you use to register emissions.<br><br>**Note:** To maintain consistency in environmental data, [!INCLUDE [prod_short](includes/prod_short.md)] restricts changes to this field after you create entries in the sustainability ledger. This restriction prevents accidental or intentional changes that could compromise emissions calculations or audit compliance. We recommend that you finalize your unit of measure during initial configuration to ensure consistent reporting. |
-    | **Waste Unit of Measure Code** | Enter the the waste unit of measure code that you use to register waste intensity. |
+    | **Waste Unit of Measure Code** | Enter the waste unit of measure code that you use to register waste intensity. |
     | **Water Unit of Measure Code** | Enter the water unit of measure code that you use to register water intensity. |
     | **Disch. Into Water Unit of Measure Code** | Enter the unit of measure code that you use to register discharged into water. |
     | **Emission Decimal Places** | Enter the number of decimal places that show for emission amounts. The default setting, *2:5*, means that a minimum of two decimal places and a maximum of five decimal places are shown for all amounts. You can also enter a fixed number. For example, if you enter *2*, two decimal places show for all amounts. |

--- a/business-central/includes/admin-setup-email-public-folder.md
+++ b/business-central/includes/admin-setup-email-public-folder.md
@@ -42,7 +42,7 @@ For more information, see [Create a public folder mailbox](/exchange/collaborati
 ### Create new public folders
 
 1. Create a new public folder with the name **Email Logging** in the root so that the full path to the folder becomes `\Email Logging\`.
-2. Create two sub-folders so that the the result is the following full paths to the folders:
+2. Create two sub-folders so that the result is the following full paths to the folders:
 
     - `\Email Logging\Queue\`
     - `\Email Logging\Storage\`

--- a/business-central/inventory-how-work-item-tracking.md
+++ b/business-central/inventory-how-work-item-tracking.md
@@ -248,7 +248,7 @@ Reclassifying item tracking for an item means to change a lot or serial number t
 
     > [!IMPORTANT]  
     > * If you're reclassifying a lot to the same lot number but with a different expiration date, you must reclassify the entire lot using one item reclassification journal line.
-    > * If you're reclassifying more than one lot to one new lot number, meaning you're merging several lots into one new lot, you must give all lots the the same new expiration date.
+    > * If you're reclassifying more than one lot to one new lot number, meaning you're merging several lots into one new lot, you must give all lots the same new expiration date.
     > * If you're reclassifying one existing lot to a second existing lot that has a different expiration date, you must use the expiration date from the second lot.
     > * If you leave the **New Expiration Date** field blank, the lot or serial number is reclassified with a blank expiration date.  
 

--- a/business-central/power-bi-faq.md
+++ b/business-central/power-bi-faq.md
@@ -95,7 +95,7 @@ The methods in this section require that guest users know the domain name of you
 1. On the **Get Data** page, select **Online Services** > **Dynamics 365 Business Central** > **Connect**.
 1. On the **Dynamics Business Central** connector dialog box, select **Sign in** and then follow the instructions to [sign in to the host's organization](#sign-in-to-hosts-organization).
 
-   :::image type="content" source="media/power-bi-desktop-connector-sign-in.png" alt-text="Shows a screenshot of the the Business Central connector sign-in dialog box":::
+   :::image type="content" source="media/power-bi-desktop-connector-sign-in.png" alt-text="Shows a screenshot of the Business Central connector sign-in dialog box":::
 
 ##### Publishing reports: Switch to host's Business Central tenant
 

--- a/business-central/production-how-to-create-work-center-calendars.md
+++ b/business-central/production-how-to-create-work-center-calendars.md
@@ -39,7 +39,7 @@ Even if your work centers do not work in different work shifts, enter at least o
     Monday  07:00 15:00 1   
     Tuesday 07:00 15:00 1  
 
-    If you need a shop calendar with two work shifts, you must fill it in in this manner:  
+    If you need a shop calendar with two work shifts, you must fill it in as follows:  
 
     Monday 07:00 15:00 1   
     Monday 15:00 23:00 2  

--- a/business-central/purchases-powerbi-kpis.md
+++ b/business-central/purchases-powerbi-kpis.md
@@ -107,7 +107,7 @@ The Budget Quantity measure sums the Quantity column from the Purchase Budget ta
 [!INCLUDE[powerbi_deprecated_measure](includes/deprecated-measures.md)]
 
 **Formula**
-The Purchase Amount measure sums the the Purchase Amount column of the Purchases table.
+The Purchase Amount measure sums the Purchase Amount column of the Purchases table.
 
 **Data Sources**
 - Value Entry
@@ -115,7 +115,7 @@ The Purchase Amount measure sums the the Purchase Amount column of the Purchases
 ### Purchase Quantity
 
 **Formula**
-The Purchase Quantity measure sums the the Purchase Quantity column of the Purchases table.
+The Purchase Quantity measure sums the Purchase Quantity column of the Purchases table.
 
 **Data Sources**
 - Value Entry

--- a/business-central/qms-quality-templates.md
+++ b/business-central/qms-quality-templates.md
@@ -63,7 +63,7 @@ To set up a quality inspection template, follow these steps.
 1. Choose **New** to create a new template.
 1. Fill in the **Template Code** field with a short name that indicates the purpose of the inspection. For example, enter **EXAMPLE** or **INCOMING-PARTS**.
 1. Fill in the **Description** field. This field often contains an elaboration of the code. For example, **Example Template** or **Incoming Parts Inspection**.
-1. In the **Sample Source** field, specify the size of the sample the test includes. Depending on your choice, the **Sample Amount** or **Sample %** fields display, so you can add those values. The **Sample quantity** in the created inspection cannot exceed the **Quantity (Base)** and if necessary it will be changed automatically on the inspection to be equal to the the source quantity. If you leave the **Sample Source** field blank, the amount or percentage fields don't display. 
+1. In the **Sample Source** field, specify the size of the sample the test includes. Depending on your choice, the **Sample Amount** or **Sample %** fields display, so you can add those values. The **Sample quantity** in the created inspection cannot exceed the **Quantity (Base)** and if necessary it will be changed automatically on the inspection to be equal to the source quantity. If you leave the **Sample Source** field blank, the amount or percentage fields don't display. 
 1. Add the tests that represent what the inspection measures.
 2. If necessary you can override conditions frorm tests for specific inspection template requirements.
 

--- a/business-central/shopify/synchronize-orders.md
+++ b/business-central/shopify/synchronize-orders.md
@@ -52,7 +52,7 @@ People who work with Shopify Admin might want to check whether orders are synchr
 
 If you want to automatically release a sales document, turn on the **Auto Release Sales Order** toggle.
 
-The **Archive Processed Shopify Orders** toggle specifies whether Shopify Connector should archive fully paid and fulfilled orders in Shopify, provided the orders meet the the following conditions.
+The **Archive Processed Shopify Orders** toggle specifies whether Shopify Connector should archive fully paid and fulfilled orders in Shopify, provided the orders meet the following conditions.
 
 - The **Fully Paid** field contains **Yes**.
 - The **Fulfillment Status** field contains **Fulfilled**.
@@ -193,7 +193,7 @@ The following procedure describes how to import and update the sales orders.
 > [!NOTE]  
 > When you filter by tags in the **Sync Order from Shopify** request page, remember that tags are stored as space-separated string, with each tag enclosed in square brackets: `[tag1] [tag2] [tag3]`.
 >
-> There can be multiple tags, so it's a good idea to use the `*` filter token. For example, if you want to import orders that contain *tag1*, use `*tag1*`. If you're unsure about the case, use the filter token `@` to ensure the the result isn't case sensitive. For example, use `@*tag1*` to get orders with tags such as *tag1*, *Tag1*, or *TAG1*.
+> There can be multiple tags, so it's a good idea to use the `*` filter token. For example, if you want to import orders that contain *tag1*, use `*tag1*`. If you're unsure about the case, use the filter token `@` to ensure the result isn't case sensitive. For example, use `@*tag1*` to get orders with tags such as *tag1*, *Tag1*, or *TAG1*.
 >
 > Other [filter criteria](../ui-enter-criteria-filters.md) also works. For example if you want several tags, use `*tag1*|*tag2*`, or if you want to skip some orders, use `<>*tag3*`.
 

--- a/business-central/ui-organization-switch.md
+++ b/business-central/ui-organization-switch.md
@@ -91,7 +91,7 @@ When you're signed in to [!INCLUDE[prod_short](includes/prod_short.md)], you can
 3. Choose the **OK** button.
 
 > [!TIP]
-> A good way to go directly to your default company when you sign in, and avoid having to specify an environment, is to add the the URL to your list of favorites after you sign in.
+> A good way to go directly to your default company when you sign in, and avoid having to specify an environment, is to add the URL to your list of favorites after you sign in.
 
 ## Use company hub
 

--- a/business-central/warehouse-how-to-set-up-basic-warehouses-with-operations-areas.md
+++ b/business-central/warehouse-how-to-set-up-basic-warehouses-with-operations-areas.md
@@ -19,7 +19,7 @@ If you have internal operation areas, such as production or assembly areas, you 
 - **Inventory Pick** page.  
 - **Inventory Put-away** page.
 
-To use these documents, you must set up one or more of the following fields on the the **Location Card** page for the location:
+To use these documents, you must set up one or more of the following fields on the **Location Card** page for the location:
 
 - The **Bin Mandatory** field.
 - The **Inventory Pick/Movement** option in the **Prod. Consumption Whse. Handling** field.


### PR DESCRIPTION
## Summary
Remove double-word typos ("the the", "in in") found by full-repo scan across 14 files.

## Changes

| File | Line | Before | After |
|------|------|--------|-------|
| admin-users-profiles-roles.md | 129 | `to the the original layout` | `to the original layout` |
| finance-sustainability-setup.md | 42 | `Enter the the waste unit` | `Enter the waste unit` |
| includes/admin-setup-email-public-folder.md | 45 | `so that the the result` | `so that the result` |
| inventory-how-work-item-tracking.md | 251 | `give all lots the the same` | `give all lots the same` |
| LocalFunctionality/UnitedStates/IRS1099 | 40 | `from the the vendor ledger entries` | `from the vendor ledger entries` |
| power-bi-faq.md | 98 | `screenshot of the the Business Central` | `screenshot of the Business Central` |
| LocalFunctionality/India/FA_Depreciation.md | 55-56 | `Specifies the the Straight/Declining` (x2) | `Specifies the Straight/Declining` |
| purchases-powerbi-kpis.md | 110, 118 | `sums the the Purchase Amount/Quantity` (x2) | `sums the Purchase Amount/Quantity` |
| qms-quality-templates.md | 66 | `equal to the the source quantity` | `equal to the source quantity` |
| shopify/synchronize-orders.md | 55, 196 | `meet the the following conditions`, `ensure the the result` | `meet the following conditions`, `ensure the result` |
| SRB/customer-contracts.md | 27 | `on the the Customer Card` | `on the Customer Card` |
| ui-organization-switch.md | 94 | `add the the URL` | `add the URL` |
| warehouse-basic-warehouses-operations-areas.md | 22 | `on the the Location Card page` | `on the Location Card page` |
| production-work-center-calendars.md | 42 | `fill it in in this manner` | `fill it in as follows` |

All edits verified against full line context before applying. No false positives included.
