### PR TITLE
Remove doubled words in finance and inventory documentation

### DIFF
--- a/business-central/assembly-how-to-sell-inventory-items-in-assemble-to-order-flows.md
+++ b/business-central/assembly-how-to-sell-inventory-items-in-assemble-to-order-flows.md
@@ -18,7 +18,7 @@ If the **Assembly Policy** field on the item card of an assembly item contains *
 It's relatively rare for businesses to sell inventory items as assemble-to-order items. Assemble-to-order items typically aren't standard. They're customized to meet specific customer requirements. However, you might have quantities of assemble-to-order items in inventory due to returns or order cancellations. Those quantities should be picked and sold before new ones are assembled.  
 
 > [!NOTE]  
-> To check whether whether assemble-to-order items are already available for assembly orders, use the **Sales Line Details** FactBox on the sales order.  
+> To check whether assemble-to-order items are already available for assembly orders, use the **Sales Line Details** FactBox on the sales order.  
 
 You can do similar things when you're selling assembly items from inventory and some or all of the quantity isn't available. You can supply the missing quantity through an assembly order. To learn more about selling inventory and assembly items, go to [Sell Assemble-to-Order Items and Inventory Items Together](assembly-how-to-sell-assemble-to-order-items-and-inventory-items-together.md).  
 

--- a/business-central/finance-consolidate-customer-vendor-balances.md
+++ b/business-central/finance-consolidate-customer-vendor-balances.md
@@ -12,7 +12,7 @@ ms.service: dynamics-365-business-central
 ms.reviewer: bholtorf
 ---
 # Consolidate Balances for a Company that is a Customer and a Vendor
-A company that you do business with might be both a customer and a vendor. When that's the case, you can avoid making unnecessary payments or receipts, and perhaps save on transaction fees, by consolidating the company's customer and vendor balances. Consolidation compares the company's balances as a vendor and as a customer, and then nets the amount so that that either the customer or vendor balance remains, depending on which amount was higher. 
+A company that you do business with might be both a customer and a vendor. When that's the case, you can avoid making unnecessary payments or receipts, and perhaps save on transaction fees, by consolidating the company's customer and vendor balances. Consolidation compares the company's balances as a vendor and as a customer, and then nets the amount so that either the customer or vendor balance remains, depending on which amount was higher. 
 
 To consolidate the balances, you must first link the customer and vendor companies through a contact that has the type **Company**. A customer or vendor can only have one contact of the type **Company**. For more information, see [Create Contacts](marketing-create-contact-companies.md).
 

--- a/business-central/finance-how-to-work-with-inventory-periods.md
+++ b/business-central/finance-how-to-work-with-inventory-periods.md
@@ -1,6 +1,6 @@
 ---
 title: Work with inventory periods
-description: You can control the timeframe in which people can post post changes to inventory by defining inventory periods.
+description: You can control the timeframe in which people can post changes to inventory by defining inventory periods.
 author: brentholtorf
 ms.topic: how-to
 ms.devlang: al

--- a/business-central/finance-setup-trail-codes.md
+++ b/business-central/finance-setup-trail-codes.md
@@ -30,7 +30,7 @@ When you post or run a batch job, the correct source code is automatically attac
 
 1. Choose the ![Search for Page or Report.](media/ui-search/search_small.png "Search for Page or Report icon") icon, enter **Source Code Setup**, and then choose the related link.  
 
-2. In the **Source Code Setup** window, for each each posting type and batch job, specify the relevant source code.  
+2. In the **Source Code Setup** window, for each posting type and batch job, specify the relevant source code.  
 
 You can change the contents of a field later, and that change will then impact future postings.
 

--- a/business-central/inventory-how-register-new-items.md
+++ b/business-central/inventory-how-register-new-items.md
@@ -119,7 +119,7 @@ If you purchase the same item from more than one vendor, you can connect those v
 
 The vendors appear on the **Item Vendor Catalog** page, which you open from the item card, so that you can easily select an alternate vendor.
 
-If you purchase the same item from more than one vendor additionally you can set up prices and discounts discounts.  For more information, see [Record Special Purchase Prices and Discounts](purchasing-how-record-purchase-price-discount-payment-agreements.md).
+If you purchase the same item from more than one vendor additionally you can set up prices and discounts.  For more information, see [Record Special Purchase Prices and Discounts](purchasing-how-record-purchase-price-discount-payment-agreements.md).
 
 ## Manage inventory in warehouses
 


### PR DESCRIPTION
Fixes five files: 'whether whether' in assembly assemble-to-order flows, 'so that that' in finance-consolidate-customer-vendor-balances, 'post post' in the description of finance-how-to-work-with-inventory-periods, 'each each' in finance-setup-trail-codes, and 'discounts discounts' in inventory-how-register-new-items.