### PR TITLE
Correct Shopify return/refund process option names to match BC UI captions

### DIFF
--- a/business-central/shopify/synchronize-orders.md
+++ b/business-central/shopify/synchronize-orders.md
@@ -70,8 +70,8 @@ If you don't want to send automatic shipping confirmations to customers, turn of
 Specify how you process returns and refunds:
 
 * **Blank** specifies that you don't import and process returns and refunds.
-* **Import only** specifies that you import information, but you manually create the corresponding credit memo.
-* **Auto create credit memo** specifies that you import information and [!INCLUDE[prod_short](../includes/prod_short.md)] automatically creates the credit memos. This option requires that you turn on the **Auto Create Sales Order** toggle.
+* **Import Only** specifies that you import information, but you manually create the corresponding credit memo.
+* **Auto Create Sales Document** specifies that you import information and [!INCLUDE[prod_short](../includes/prod_short.md)] automatically creates the credit memos. This option requires that you turn on the **Auto Create Sales Order** toggle.
 
 Specify a location for returns, and G/L accounts for refunds for goods and other refunds.
 


### PR DESCRIPTION
The return/refund processing options listed in this article did not match what Business Central shows in the UI.

The Shopify connector enum ShpfyReturnRefundProcessType (ID 30139) in BCApps defines these captions:

- value 1: "Import Only" (was documented as "Import only")
- value 3: "Auto Create Sales Document" (was documented as "Auto create credit memo")

The enum value identifier is still "Auto Create Credit Memo" internally, but the displayed caption was changed to "Auto Create Sales Document". A user reading this doc and searching the Shopify Shop Card for "auto create credit memo" will not find the option.

Verified against: BCApps/src/Apps/W1/Shopify/App/src/Order Return Refund Processing/Enums/ShpfyReturnRefundProcessType.Enum.al