### PR TITLE
Document Process Returns as field and auto-release behavior for Shopify refund documents

### DIFF
--- a/business-central/shopify/synchronize-orders.md
+++ b/business-central/shopify/synchronize-orders.md
@@ -73,6 +73,11 @@ Specify how you process returns and refunds:
 * **Import only** specifies that you import information, but you manually create the corresponding credit memo.
 * **Auto create credit memo** specifies that you import information and [!INCLUDE[prod_short](../includes/prod_short.md)] automatically creates the credit memos. This option requires that you turn on the **Auto Create Sales Order** toggle.
 
+When **Auto Create Sales Document** is selected, the **Process Returns as** field on the **Shopify Shop Card** controls whether the connector creates a sales credit memo or a sales return order. The created document is automatically released after the lines are populated, regardless of the **Auto Release Sales Orders** setting on the shop card.
+
+> [!NOTE]
+> The connector can only create the sales document if the original Shopify order was already processed into a [!INCLUDE [prod_short](../includes/prod_short.md)] sales document. If the original order hasn't been processed yet, the refund is imported but the sales document creation is skipped and an error is recorded on the refund.
+
 Specify a location for returns, and G/L accounts for refunds for goods and other refunds.
 
 You can use the original return location from Shopify for refunds and returns. The location helps ensure that locations are accurate on credit memos, which reduces manual adjustments and streamlines the returns process.


### PR DESCRIPTION
Two behaviors of the "Auto Create Sales Document" returns processing mode were undocumented.

**Process Returns as field** (ShpfyShop.Table.al, field 137, caption "Process Returns as"):

The connector passes Shop."Process Returns As" to ShpfyCreateSalesDocRefund.SetTargetDocumentType(), which sets the Sales Document Type used when creating the refund document. Without this, users have no indication that the document type is configurable and assume credit memos are always created.

**Auto-release behavior** (ShpfyCreateSalesDocRefund.Codeunit.al, CreateSalesDocument procedure):

ReleaseSalesDocument.Run() is called unconditionally after lines are populated. The main order processing in ShpfyProcessOrder.OnRun() checks the "Auto Release Sales Orders" toggle before releasing, but the refund path has no such condition. Users who turn off "Auto Release Sales Orders" expecting to review refund documents before release will be surprised.

**Original order must be processed** (ShpfyRetRefProcCrMemo.Codeunit.al, CanCreateSalesDocumentFor):

The actual guard is OrderHeader.IsProcessed() or OrderHeader.Processed, not a toggle check. The existing description says "requires Auto Create Sales Order toggle" but what is actually required is that the underlying BC sales document already exists for the Shopify order.