### PR TITLE
Document PO Number to External Document No. and Prices Including VAT mapping for Shopify orders

### DIFF
--- a/business-central/shopify/synchronize-orders.md
+++ b/business-central/shopify/synchronize-orders.md
@@ -324,10 +324,10 @@ Bill-to fields have the billing address specified in the Shopify order. One reas
 
 ### Other fields in the created sales document
 
-The connector also populates the following header fields from the Shopify order:
+The connector also fills in the following header fields from the Shopify order:
 
-* **External Document No.** is set from the **PO Number** field on the Shopify order. This lets you cross-reference a buyer's purchase order number on the BC sales document.
-* **Prices Including VAT** is set from the **VAT Included** flag on the Shopify order. If the Shopify store is configured to include tax in prices, the imported sales document will have **Prices Including VAT** set to true, which changes how tax amounts are calculated and displayed on the document.
+* The **External Document No.** field has the value from the **PO Number** field on the Shopify order. This information lets you cross-reference a buyer's purchase order number on the sales order in Business Central.
+* The **Prices Including VAT** setting depends on whether **VAT Included** is enabled on the Shopify order. If the Shopify store is configured to include tax in prices, the imported sales document has the **Prices Including VAT** checkbox selected, which changes how tax amounts are calculated and displayed on the document.
 
 ### Locations in the created sales document
 

--- a/business-central/shopify/synchronize-orders.md
+++ b/business-central/shopify/synchronize-orders.md
@@ -322,6 +322,13 @@ Bill-to fields have the billing address specified in the Shopify order. One reas
 > [!NOTE]  
 > To ensure that you can review address details in the created sales document, set both the **Ship-to** and **Bill-to** fields to **Custom Address**.
 
+### Other fields in the created sales document
+
+The connector also populates the following header fields from the Shopify order:
+
+* **External Document No.** is set from the **PO Number** field on the Shopify order. This lets you cross-reference a buyer's purchase order number on the BC sales document.
+* **Prices Including VAT** is set from the **VAT Included** flag on the Shopify order. If the Shopify store is configured to include tax in prices, the imported sales document will have **Prices Including VAT** set to true, which changes how tax amounts are calculated and displayed on the document.
+
 ### Locations in the created sales document
 
 For each sales document line that requires fulfillment, the connector locates fulfillment order lines that link to the same order and contain an identical product and variant. The connector prioritizes fulfillment orders with statuses that differ from CLOSED. When it finds such fulfillment lines, the connector uses the **Location ID** from the fulfillment line. If multiple fulfillment lines for the same order line exist but reference different locations, only one location is used.


### PR DESCRIPTION
Two header fields populated during order processing were not documented.

**External Document No. from PO Number** (ShpfyProcessOrder.Codeunit.al, line 133):

The connector writes the Shopify PO Number field (ShpfyOrderHeader field 126) directly into External Document No. on every created sales document. Relevant for B2B buyers who supply a PO number at checkout and expect it to appear on invoices and shipment confirmations.

Code: SalesHeader.Validate("External Document No.", ShopifyOrderHeader."PO Number")

**Prices Including VAT from VAT Included** (ShpfyProcessOrder.Codeunit.al, line 123):

The connector reads the VAT Included boolean from the Shopify order (ShpfyOrderHeader field 72) and applies it to Prices Including VAT. If the Shopify store has "Include tax in prices" enabled, every imported sales document will have Prices Including VAT = true, which affects line-level tax amounts and totals. Without this note, users troubleshooting tax discrepancies between Shopify and BC have no starting point.

Code: SalesHeader.Validate("Prices Including VAT", ShopifyOrderHeader."VAT Included")