### PR TITLE
Document which transaction types Suggest Shopify Payments processes in transactions-and-payouts.md

### DIFF
--- a/business-central/shopify/transactions-and-payouts.md
+++ b/business-central/shopify/transactions-and-payouts.md
@@ -154,6 +154,9 @@ The Merchant imports a sales order to [!INCLUDE [prod_short](../includes/prod_sh
 
 The Merchant processes the imported Shopify transactions in the **Transactions** list. They apply filters, and then use the **Suggest Shopify Payments** action to transfer the transactions to the general journal. Alternatively, the Merchant can use the **Suggest Shopify Payments** action on the **Cash Receipt Journal** page.
 
+> [!NOTE]
+> The **Suggest Shopify Payments** action only processes transactions of type **Capture**, **Sale**, and **Refund** with a status of **Success**. Transactions of type **Authorization** and **Void** are excluded regardless of any filters you apply. On the report request page, you can also turn on the **Include Order No. in Description** toggle to include the Shopify order number in journal line descriptions instead of the internal order ID. Enabling this option may decrease performance.
+
 The Merchant reviews the lines, and notices that the applied documents are selected automatically. They post the journal, and [!INCLUDE [prod_short](../includes/prod_short.md)] creates a customer ledger entry of the type **Payment** and applies it to the corresponding entry of the type **Invoice**.
 
 > [!NOTE] 

--- a/business-central/shopify/transactions-and-payouts.md
+++ b/business-central/shopify/transactions-and-payouts.md
@@ -155,7 +155,10 @@ The Merchant imports a sales order to [!INCLUDE [prod_short](../includes/prod_sh
 The Merchant processes the imported Shopify transactions in the **Transactions** list. They apply filters, and then use the **Suggest Shopify Payments** action to transfer the transactions to the general journal. Alternatively, the Merchant can use the **Suggest Shopify Payments** action on the **Cash Receipt Journal** page.
 
 > [!NOTE]
-> The **Suggest Shopify Payments** action only processes transactions of type **Capture**, **Sale**, and **Refund** with a status of **Success**. Transactions of type **Authorization** and **Void** are excluded regardless of any filters you apply. On the report request page, you can also turn on the **Include Order No. in Description** toggle to include the Shopify order number in journal line descriptions instead of the internal order ID. Enabling this option may decrease performance.
+> The **Suggest Shopify Payments** action only processes transactions of type **Capture**, **Sale**, and **Refund** with a status of **Success**. Transactions of type **Authorization** and **Void** are always excluded, regardless of filters applied in the **Transactions** list.
+
+> [!TIP]
+> On the report request page, you can turn on the **Include Order No. in Description** toggle to use the Shopify order number in journal line descriptions instead of the internal order ID. Enabling this option might decrease performance because it requires extra lookups to resolve order numbers.
 
 The Merchant reviews the lines, and notices that the applied documents are selected automatically. They post the journal, and [!INCLUDE [prod_short](../includes/prod_short.md)] creates a customer ledger entry of the type **Payment** and applies it to the corresponding entry of the type **Invoice**.
 


### PR DESCRIPTION
The "Reconcile transactions and bank statements" section describes using Suggest Shopify Payments but omits two important behaviors that affect what users see when running it.

**Changes**

Added a NOTE block immediately after the Suggest Shopify Payments paragraph to document:

- Only transactions of type Capture, Sale, and Refund with status Success are processed. Authorization and Void type transactions are always excluded, regardless of any filters applied in the Transactions list.
- The report request page has an "Include Order No. in Description" toggle that replaces the internal order ID with the Shopify order number in journal line descriptions. The toggle is off by default because enabling it may decrease performance.

**Verified against**

BCApps: src/Apps/W1/Shopify/App/src/Transactions/Reports/ShpfySuggestPayments.Report.al

DataItemTableView filter: Type = filter(Capture | Sale | Refund), Status = filter(Success)

Request page field "Transaction Gateway" and "Order No. In Description" with ToolTip confirming the performance note.
