### PR TITLE
Correct spelling errors in service walkthrough and Power BI docs

### DIFF
--- a/business-central/contoso-coffee/service/service-contract-flow.md
+++ b/business-central/contoso-coffee/service/service-contract-flow.md
@@ -87,7 +87,7 @@ Charles, the service manager, creates service orders for regular maintenance ord
 1. Run the service orders that fulfill the obligations of active service contracts.
 
    1. Choose the ![Lightbulb that opens the Tell Me feature.](../../media/ui-search/search_small.png "Tell me what you want to do") icon, enter **Create Contract Service Orders**, and then choose the related link.
-   2. Enter *01* in the **Starting Date** field. It will be transformed into begining of the month based on work date. 
+   2. Enter *01* in the **Starting Date** field. It will be transformed into beginning of the month based on work date. 
    3. Enter the ending date of the month in the **Ending Date** field.
    4. Choose **OK** to confirm creation of service orders. You receive a confirmation message with the number of created service orders.
 

--- a/business-central/powerbi-use-semantic-models-in-excel.md
+++ b/business-central/powerbi-use-semantic-models-in-excel.md
@@ -128,7 +128,7 @@ To open the Power Pivot model, choose to **Data** > **Data Tools** > **Data Mode
 
 :::image type="content" source="media\powerbi\excel\excel-manage-data-model.png" alt-text="Screenshot of Excel showing steps to Manage Data Model in Power Pivot. " lightbox="media\powerbi\excel\excel-manage-data-model.png":::
 
-Review the created relationship in the Modelling view of Power Pivot. Create a Pivot Table to utilise the connection between the two tables.
+Review the created relationship in the Modelling view of Power Pivot. Create a Pivot Table to utilize the connection between the two tables.
 
 :::image type="content" source="media\powerbi\excel\excel-create-pivot-from-power-pivot.png" alt-text="Screenshot of Excel showing steps to create Pivot Table from Power Pivot." lightbox="media\powerbi\excel\excel-create-pivot-from-power-pivot.png":::
 


### PR DESCRIPTION
Two files contain straightforward spelling errors.

contoso-coffee/service/service-contract-flow.md line 90: 'begining' corrected to 'beginning'.

powerbi-use-semantic-models-in-excel.md line 131: 'utilise' corrected to 'utilize' to match the American English used throughout the documentation.
