### PR TITLE
Correct spelling and product page name in planning walkthrough and finance docs

### DIFF
--- a/business-central/includes/power-bi-finance-app.md
+++ b/business-central/includes/power-bi-finance-app.md
@@ -16,6 +16,6 @@ The following table describes the reports in the [!INCLUDE [power-bi-finance-app
 |Analyze general ledger entries in detail, and slice G/L entries by all eight shortcut dimensions. | [General Ledger Entries](https://businesscentral.dynamics.com?page=36995) |[About General Ledger Entries](../finance-powerbi-general-ledger-entries.md) |
 | [!INCLUDE [pbireport-detailed-vendor-ledger-entries-include](pbireport-detailed-vendor-ledger-entries-include.md)] | [Detailed Vendor Ledger Entries](https://businesscentral.dynamics.com?page=36996) | [About Detailed Vendor Ledger Entries](../finance-powerbi-detailed-vendor-ledger-entries.md) |
 |Analyze entries posted to the Customer Ledger and Detailed Customer Sub Ledger.| [Detailed Customer Ledger Entries](https://businesscentral.dynamics.com?page=36997) | [About Detailed Customer Ledger Entries](../finance-powerbi-detailed-customer-ledger-entries.md) |
-|Analyze the behaviours of late paying customers and their financial impact. | [Late Payments Receivables](https://businesscentral.dynamics.com?page=37113) | [About Late Payments (Receivables)](../finance-powerbi-late-payment-analysis-receivables.md) |
+|Analyze the behaviors of late paying customers and their financial impact. | [Late Payments Receivables](https://businesscentral.dynamics.com?page=37113) | [About Late Payments (Receivables)](../finance-powerbi-late-payment-analysis-receivables.md) |
 
 [!INCLUDE[powerbi-tip-track-kpis](powerbi-tip-track-kpis.md)]

--- a/business-central/walkthrough-planning-supplies-manually.md
+++ b/business-central/walkthrough-planning-supplies-manually.md
@@ -110,7 +110,7 @@ The **Order Planning** page can be accessed from several different locations:
     >  If the components have a default vendor number set up on the item cards, the lines will be preset.  
 
 6.  Choose the **Supply From**  field.  
-7.  On the **Item Vendor Catalogue** page, choose the **New** action, and then select vendor **30000**.  
+7.  On the **Item Vendor Catalog** page, choose the **New** action, and then select vendor **30000**.  
 8.  Choose the **OK** button to return to the **Order Planning** page.  
 9. Copy vendor **30000** to the other lines for loudspeaker components on this production order.  
 
@@ -229,3 +229,4 @@ The **Order Planning** page can be accessed from several different locations:
 
 
 [!INCLUDE[footer-include](includes/footer-banner.md)]
+


### PR DESCRIPTION
Correct two documentation accuracy issues in the planning walkthrough and Power BI finance app docs.

Changes:

- power-bi-finance-app.md (via includes): "behaviours" changed to "behaviors" (American English)
- walkthrough-planning-supplies-manually.md: "Item Vendor Catalogue" changed to "Item Vendor Catalog"

The second change is a product name accuracy fix. The BC page is named "Item Vendor Catalog" in source code (Page::"Item Vendor Catalog"), not "Item Vendor Catalogue".
