### PR TITLE
Correct toggle names in Shopify get started doc

### DIFF
--- a/business-central/shopify/get-started.md
+++ b/business-central/shopify/get-started.md
@@ -102,11 +102,11 @@ This configuration *isn't* recommended for testing because the Shopify Connector
 
 If you must use this configuration, we recommend that you review and probably disable the following settings:
 
-- **Auto Create Unknown Item** to not create items.
-- **Shopify can update items** to not update mapped items.
-- **Auto Create Unknown Customer** to not create customers and contacts.
-- **Shopify can update customers** to not update existing customers.
-- **Auto Create Sales Order** to not create sales orders and sales invoices.
+- **Auto Create Unknown Items** to not create items.
+- **Shopify Can Update Items** to not update mapped items.
+- **Auto Create Unknown Customers** to not create customers and contacts.
+- **Shopify Can Update Customers** to not update existing customers.
+- **Auto Create Sales Documents** to not create sales orders and sales invoices.
 
 For more information, see [Restoring an Environment](/dynamics365/business-central/dev-itpro/administration/tenant-admin-center-backup-restore).
 


### PR DESCRIPTION
Five toggle names in the Shopify get started doc do not match the field captions in `ShpfyShop.Table.al`.

**Auto Create Unknown Item** (singular) corrected to **Auto Create Unknown Items** (plural).
Field 22 caption: `'Auto Create Unknown Items'`.

**Shopify can update items** (lowercase 'can') corrected to **Shopify Can Update Items** (title case).
Field 39 caption: `'Shopify Can Update Items'`.

**Auto Create Unknown Customer** (singular) corrected to **Auto Create Unknown Customers** (plural).
Field 23 caption: `'Auto Create Unknown Customers'`.

**Shopify can update customers** (lowercase 'can') corrected to **Shopify Can Update Customers** (title case).
Field 30 caption: `'Shopify Can Update Customers'`.

**Auto Create Sales Order** corrected to **Auto Create Sales Documents**.
Field 21 caption: `'Auto Create Sales Documents'`.
