### PR TITLE
Correct toggle names in Shopify walkthrough doc

### DIFF
--- a/business-central/shopify/walkthrough-setting-up-and-using-shopify.md
+++ b/business-central/shopify/walkthrough-setting-up-and-using-shopify.md
@@ -52,8 +52,8 @@ To configure the Shopify shop, follow these steps:
 7. Turn on the **Auto Create Unknown Customers** toggle.
 8. Fill in the **Customer/Company Template Code** field with the appropriate template.
 9. Fill in the **Shipping Cost Account**, the **Tip Account** with the revenue account. For example, in the US, use **40210**.
-10. Turn on the **Auto Create Orders** toggle.
-11. Turn off the **Auto Release Sales Orders** toggle.
+10. Turn on the **Auto Create Sales Documents** toggle.
+11. Turn off the **Auto Release Sales Documents** toggle.
 
 Configure location mapping:
 
@@ -377,7 +377,7 @@ Configure the Shopify shop as described here:
 8. Turn on the **Auto Create Unknown Customers** toggle.
 9. Fill in the **Customer/Company Template Code** field with the appropriate template.
 10. In the **Company Import from Shopify** field, select **All Customers**.
-11. Turn on the **Auto Create Unknown Company** toggle.
+11. Turn on the **Auto Create Unknown Companies** toggle.
 
 #### Run the synchronization
 


### PR DESCRIPTION
Three toggle names in the Shopify walkthrough doc do not match the field captions in `ShpfyShop.Table.al`.

**Auto Create Orders corrected to Auto Create Sales Documents (line 55)**

Field 21 caption is `'Auto Create Sales Documents'`. The walkthrough used the field name (`"Auto Create Orders"`) rather than the caption shown in the UI.

**Auto Release Sales Orders corrected to Auto Release Sales Documents (line 56)**

Field 60 caption is `'Auto Release Sales Documents'`. The walkthrough used the field name (`"Auto Release Sales Orders"`) rather than the caption shown in the UI.

**Auto Create Unknown Company corrected to Auto Create Unknown Companies (line 380)**

Field 123 caption is `'Auto Create Unknown Companies'` (plural). The walkthrough used the singular form `Company` which does not match the caption.
