### PR TITLE
Remove repeated word in product error messages doc

### DIFF
--- a/business-central/product-error-messages.md
+++ b/business-central/product-error-messages.md
@@ -35,7 +35,7 @@ To overcome obstacles and minimize downtime, apply the expertise of colleagues o
 
 The details include the error message, error code, and other information that's helpful when troubleshooting an error. By sharing the error details, you can effectively communicate the specific issue you're facing, which helps your colleagues help you.  
 
-You can copy details by choosing the **Share icon** in in-line validation dialogs, or the **Share details** menu in error dialogs.  
+You can copy details by choosing the **Share icon** in inline validation dialogs, or the **Share details** menu in error dialogs.  
 
 In addition to copying error details, you can also choose to share details through Microsoft Teams by choosing **Share details to Teams** to do the following:
 


### PR DESCRIPTION
Line 38 reads "the **Share icon** in in-line validation dialogs" where `in` appears twice consecutively. The second `in` is the start of `in-line` but it reads as a repeated word.

Changed `in in-line` to `in inline` (one word, modern standard usage) to eliminate the repetition and improve readability.
