### PR TITLE
Simplify 'in order to' to 'to' in walkthrough and marketing docs

### DIFF
--- a/business-central/marketing-campaigns.md
+++ b/business-central/marketing-campaigns.md
@@ -40,7 +40,7 @@ After you set up your campaign, you can register a discount percentage that the 
 After you set up the sales prices/line discounts and the segments on the campaign card, you must activate them so that the campaign prices/discounts are reflected on the lines.
 
 > [!NOTE]  
-> In order to activate the sales prices/line discounts, you must specify if the whole segment or only some contacts are targets of the campaign. If the sales prices/line discounts covers all the contacts in the segment, select the **Campaign Target** field on the **Campaign** FastTab of the **Segment** card.
+> To activate the sales prices/line discounts, you must specify if the whole segment or only some contacts are targets of the campaign. If the sales prices/line discounts covers all the contacts in the segment, select the **Campaign Target** field on the **Campaign** FastTab of the **Segment** card.
 
 If the sales prices/line discounts aren't to be offered to all the contacts in the segment, you can clear the **Campaign Target** field for the relevant contacts. If you can't see this field, you can add it to your view. Learn more in [Personalize Your Workspace](ui-personalization-user.md).
 

--- a/business-central/walkthrough-business-process-walkthroughs.md
+++ b/business-central/walkthrough-business-process-walkthroughs.md
@@ -13,7 +13,7 @@ ms.reviewer: bholtorf
 ---
 # Business Process Walkthroughs
 
-This selection of walkthroughs provides step-by-step, end-to-end business processes that you can perform using the CRONUS demonstration company. The walkthroughs consist of multiple procedures, some of which would normally be performed by one user, while others incorporate several different user roles. In order to simulate the working environment, some of the walkthroughs contain setup steps necessary to complete the exercises as described. These steps can provide insight into the kind of information users need to share with their company's IT professionals.  
+This selection of walkthroughs provides step-by-step, end-to-end business processes that you can perform using the CRONUS demonstration company. The walkthroughs consist of multiple procedures, some of which would normally be performed by one user, while others incorporate several different user roles. To simulate the working environment, some of the walkthroughs contain setup steps necessary to complete the exercises as described. These steps can provide insight into the kind of information users need to share with their company's IT professionals.  
 
  The walkthroughs are complete scenarios, and should be performed from beginning to end for the greatest benefit. Many are based on [!INCLUDE[prod_short](includes/prod_short.md)] demonstrations, and enable you to try those procedures yourself, at your own pace.  
 

--- a/business-central/walkthrough-managing-projects-with-jobs.md
+++ b/business-central/walkthrough-managing-projects-with-jobs.md
@@ -42,7 +42,7 @@ With the budget structure set up for projects, creating a project is straightfor
 
 ### Copying a project
 
- This part of the walkthrough focuses on how to copy part or all of a project in order to reduce manual data entry and improve accuracy.
+ This part of the walkthrough focuses on how to copy part or all of a project to reduce manual data entry and improve accuracy.
 
 - Copy part of a project to a new project.  
 - Copy project-specific prices.  
@@ -101,7 +101,7 @@ To prepare for this walkthrough, you must add Tricia as a resource.
 
 6. Close the page.
 
-In the next procedure, you create a project journal batch for Tricia in order to post their usage.  
+In the next procedure, you create a project journal batch for Tricia to post their usage.  
 
 ### To create a project journal batch  
 


### PR DESCRIPTION
Three docs use "in order to" where a plain "to" is more concise, per Microsoft Writing Style Guide.

Changes:
- `marketing-campaigns.md`: "In order to activate" to "To activate"
- `walkthrough-business-process-walkthroughs.md`: "In order to simulate" to "To simulate"
- `walkthrough-managing-projects-with-jobs.md`: "in order to reduce" to "to reduce"; "in order to post" to "to post"
