### PR TITLE
Simplify 'in order to' to 'to' in service, inventory, and production docs

### DIFF
--- a/business-central/inventory-how-setup-item-tracking.md
+++ b/business-central/inventory-how-setup-item-tracking.md
@@ -18,7 +18,7 @@ Items with serial and lot numbers can be traced both backwards and forward in th
 
 ## Numbers and item tracking
 
-As part of your warehouse processes, you can bundle your stock in packages, boxes, containers, and so on. But in order to keep track of the items, you assign unique numbers as identification. For example, you manufacture and sell a chair that has the item number *1900-S*. Each chair has a serial number, *1001*, but you also bundle four chairs into a lot, *LOT0001*. You also ship the chairs in a container with the package number *CONTAINER010* that also includes *LOT0100* with side tables, and *LOT200* with lamps.  
+As part of your warehouse processes, you can bundle your stock in packages, boxes, containers, and so on. But to keep track of the items, you assign unique numbers as identification. For example, you manufacture and sell a chair that has the item number *1900-S*. Each chair has a serial number, *1001*, but you also bundle four chairs into a lot, *LOT0001*. You also ship the chairs in a container with the package number *CONTAINER010* that also includes *LOT0100* with side tables, and *LOT200* with lamps.  
 
 Depending on your configuration, you use these different numbers to keep track of inventory in [!INCLUDE [prod_short](includes/prod_short.md)] at the various stages of purchasing, sales, warehouse operations, and so on.
 

--- a/business-central/production-about-production-orders.md
+++ b/business-central/production-about-production-orders.md
@@ -161,7 +161,7 @@ When you refresh the production order, the flushing method is copied from the it
 
 ### Production output  
 
-You can track the time spent working on a production order and the quantity produced. This information can help you determine the costs of production. Also, manufacturers who use a standard costing system might want to record actual information in order to help them develop better standards.  
+You can track the time spent working on a production order and the quantity produced. This information can help you determine the costs of production. Also, manufacturers who use a standard costing system might want to record actual information to help them develop better standards.  
 
 Output can be processed through [output journals](production-how-to-post-output-quantity.md), but can also be recorded automatically. [!INCLUDE [prod_short](includes/prod_short.md)] copies the flushing method from the machine center or work center card to the production order routing when refreshing. As with material consumption, there are **Manual**, **Forward**, and **Backward** reporting methods for output.
 

--- a/business-central/service-allocation-status-and-repair-status.md
+++ b/business-central/service-allocation-status-and-repair-status.md
@@ -24,7 +24,7 @@ When you change the repair status of a service item on a service item line, ther
 * When a service order allocation entry is created that indicates that no resource has been allocated, the **Status** field on the **Resource Allocation** page is set to **Nonactive**.  
 * The allocation entry status is set to **Canceled** when you reallocate the referred service item in the service order allocation entry, which indicates that the allocated resource or resource group hasn't attempted the service task.  
   
-The allocation status reflects when the service process is finished, or when another resource is necessary in order to finish the service of the service item.  
+The allocation status reflects when the service process is finished, or when another resource is necessary to finish the service of the service item.  
   
 ## Convert service quotes to service orders
 


### PR DESCRIPTION
Three docs use "in order to" where a plain "to" is more concise, per Microsoft Writing Style Guide.

Changes:
- `service-allocation-status-and-repair-status.md`: "in order to finish" to "to finish"
- `inventory-how-setup-item-tracking.md`: "in order to keep track" to "to keep track"
- `production-about-production-orders.md`: "in order to help" to "to help"
