### PR TITLE
Simplify 'in order to' to 'to' in design and admin docs

### DIFF
--- a/business-central/admin-how-to-modify-table-mappings-for-synchronization.md
+++ b/business-central/admin-how-to-modify-table-mappings-for-synchronization.md
@@ -145,7 +145,7 @@ You can add more templates, and use filters to define conditions under which [!I
    > [!NOTE]
    > The **Table Config Template Code** and **Int. Tbl. Config Template Code** fields show different values depending on the number of templates that you configure for a specific integration table mapping:
    >
-   > * If you configure a single configuration template, the name of the configuration template shows to stay compatible with current capabilities.
+   > * If you configure a single configuration template, the name of the configuration template is displayed to stay compatible with current capabilities.
    > * If you configure multiple configuration templates, the number of configured configuration templates shows.
 
 4. Set the **Int. Tbl. Config Template Code** field to the configuration template to use for new records in [!INCLUDE[prod_short](includes/cds_long_md.md)].

--- a/business-central/admin-how-to-modify-table-mappings-for-synchronization.md
+++ b/business-central/admin-how-to-modify-table-mappings-for-synchronization.md
@@ -145,7 +145,7 @@ You can add more templates, and use filters to define conditions under which [!I
    > [!NOTE]
    > The **Table Config Template Code** and **Int. Tbl. Config Template Code** fields show different values depending on the number of templates that you configure for a specific integration table mapping:
    >
-   > * If you configure a single configuration template, the name of the configuration template shows in order to stay compatible with current capabilities.
+   > * If you configure a single configuration template, the name of the configuration template shows to stay compatible with current capabilities.
    > * If you configure multiple configuration templates, the number of configured configuration templates shows.
 
 4. Set the **Int. Tbl. Config Template Code** field to the configuration template to use for new records in [!INCLUDE[prod_short](includes/cds_long_md.md)].

--- a/business-central/design-details-balancing-demand-and-supply.md
+++ b/business-central/design-details-balancing-demand-and-supply.md
@@ -89,7 +89,7 @@ Order priorities are applied to the different types to fulfill the most importan
 
 Demand can also be negative. Treat negative demand as supply. However, unlike typical supply, negative demand is considered fixed supply. The planning system can take it into account, but will not suggest changes to it.  
 
-In general, the planning system considers all supply orders after the planning starting date as subject to change in order to fulfill demand. However, after a quantity is posted from a supply order the planning system can't change it. The following orders can't be replanned:  
+In general, the planning system considers all supply orders after the planning starting date as subject to change to fulfill demand. However, after a quantity is posted from a supply order the planning system can't change it. The following orders can't be replanned:  
 
 * Released production orders where consumption or output has been posted.  
 * Assembly orders where consumption or output has been posted.  

--- a/business-central/design-details-handling-reordering-policies.md
+++ b/business-central/design-details-handling-reordering-policies.md
@@ -80,7 +80,7 @@ The following image shows this principle.
 
 ## The role of the time bucket
 
-The purpose of the time bucket is to collect demand events within a time period in order to make a joint supply order.  
+The purpose of the time bucket is to collect demand events within a time period to make a joint supply order.  
 
 For reordering policies that use a reorder point, you can define a time bucket. Time buckets help ensure that demands within the same time period are accumulated. The system then checks the effect on projected inventory and whether the reorder point is passed.
 
@@ -266,7 +266,7 @@ Supply orders that are created specifically to meet a reorder point are excluded
 
 The Minimum Order Quantity, Maximum Order Quantity, and Order Multiple order modifiers shouldn't play a significant role when you use the Fixed Reorder Qty. policy. However, the planning system takes them into account:
 
-* Decrease the quantity to the specified maximum order quantity (and create two or more supplies in order to reach the total order quantity)
+* Decrease the quantity to the specified maximum order quantity (and create two or more supplies to reach the total order quantity)
 * Increase the order to the specified minimum order quantity
 * Round up the order quantity to meet a specified order multiple  
 


### PR DESCRIPTION
Three docs use "in order to" where a plain "to" is more concise, per Microsoft Writing Style Guide.

Changes:
- `admin-how-to-modify-table-mappings-for-synchronization.md` L148: "shows in order to stay compatible" to "shows to stay compatible"
- `design-details-balancing-demand-and-supply.md` L92: "in order to fulfill demand" to "to fulfill demand"
- `design-details-handling-reordering-policies.md` L83: "in order to make a joint supply order" to "to make a joint supply order"
- `design-details-handling-reordering-policies.md` L269: "in order to reach the total order quantity" to "to reach the total order quantity"
