### PR TITLE
Simplify 'in order to' to 'to' in planning, e-document, and marketing docs

### DIFF
--- a/business-central/design-details-planning-assignment-table.md
+++ b/business-central/design-details-planning-assignment-table.md
@@ -17,7 +17,7 @@ If the user has entered a new sales order or changed an existing one, there is r
 
 For multiple locations, the assignment takes place at the level of item per location combination. If, for example, a sales order has been created at only one location, application will assign the item at that specific location for planning.  
 
-The reason for selecting items for planning is a matter of system performance. If no change in an item’s demand-supply pattern has occurred, the planning system will not suggest any actions to be taken. Without the planning assignment, the system would have to perform the calculations for all items in order to find out what to plan for, and that would drain system resources.  
+The reason for selecting items for planning is a matter of system performance. If no change in an item’s demand-supply pattern has occurred, the planning system will not suggest any actions to be taken. Without the planning assignment, the system would have to perform the calculations for all items to find out what to plan for, and that would drain system resources.  
 
 The **Planning Assignment** table monitors demand and supply events and assigns the appropriate items for planning. The following events are monitored:  
 

--- a/business-central/finance-how-setup-edocuments.md
+++ b/business-central/finance-how-setup-edocuments.md
@@ -164,7 +164,7 @@ However, to enable the new **E-Document** framework, you must configure the **Do
 The E-Document framework supports several options for sending documents:
 
 - **Service-based sending**: Use **Extended E-Document Service Flow** with an **E-Document Workflow** to send documents through configured service integrations.
-- **Email-based sending**: Enable **Email** and select **E-Document** or **PDF & E-Document** as the attachment type to send e-documents via email. Email-based sending relies on the e-document workflow to run in order to export the e-document. To use this option, you must fill in the **E-Document Workflow** field.
+- **Email-based sending**: Enable **Email** and select **E-Document** or **PDF & E-Document** as the attachment type to send e-documents via email. Email-based sending relies on the e-document workflow to run to export the e-document. To use this option, you must fill in the **E-Document Workflow** field.
 - **Combined sending**: Use both service-based and email-based sending together to send through a service integration and email the document simultaneously.
 
 ## Creating e-documents from posted documents

--- a/business-central/marketing-setup-contacts.md
+++ b/business-central/marketing-setup-contacts.md
@@ -170,7 +170,7 @@ Learn more at [Synchronizing contacts with customers, vendors, and bank accounts
 
 When you create a contact, [!INCLUDE [prod_short](includes/prod_short.md)] can automatically search for duplicates. Avoiding duplicate contacts can help ensure that you interact with the right person for the right company.
 
-You can specify the percentage of identical data that two contacts must have in order to consider them duplicates. You can also just use the default percentage, which is 60. You specify the percentage on the **Marketing Setup** page by entering a percentage value in the **Search Hit %** field on the **Duplicates** FastTab.
+You can specify the percentage of identical data that two contacts must have to consider them duplicates. You can also just use the default percentage, which is 60. You specify the percentage on the **Marketing Setup** page by entering a percentage value in the **Search Hit %** field on the **Duplicates** FastTab.
 
 For automatic searches, when you create a contact that already has a business relation to a company, [!INCLUDE [prod_short](includes/prod_short.md)] displays a message to inform you.
 


### PR DESCRIPTION
Three docs use "in order to" where plain "to" is more concise, per Microsoft Writing Style Guide.

Changes:
- `design-details-planning-assignment-table.md` L20: "in order to find out" to "to find out"
- `finance-how-setup-edocuments.md` L167: "to run in order to export" to "to run to export"
- `marketing-setup-contacts.md` L173: "in order to consider them duplicates" to "to consider them duplicates"
