### PR TITLE
Simplify 'in order to' to 'to' in sales and service setup docs

### DIFF
--- a/business-central/sales-how-to-set-up-customer-discount-groups.md
+++ b/business-central/sales-how-to-set-up-customer-discount-groups.md
@@ -21,7 +21,7 @@ You can define sales line discounts for a group of customers instead of applying
 3. Choose the **Sales Line Discounts** action.
 4. Fill in the **Sales Code** column with the discount group created on the previous page.
 5. Fill in the fields on the lines with the **Type** (Item or Item Discount Group), **Code**, **Unit of Measure Code**, and the **Line Discount %**.
-6. If the customer group needs to purchase a minimum quantity in order to gain the discount, fill in the **Minimum Quantity** field.
+6. If the customer group needs to purchase a minimum quantity to gain the discount, fill in the **Minimum Quantity** field.
 7. If necessary, enter the **Starting Date** and **Ending Date** for the discount group.
 8. If relevant, you can also specify the **Currency Code** or **Variant Code** after [personalizing the columns](ui-personalization-user.md).
 

--- a/business-central/sales-how-to-set-up-customer-price-groups.md
+++ b/business-central/sales-how-to-set-up-customer-price-groups.md
@@ -36,7 +36,7 @@ When you have agreed on the prices that the group of customers will pay for cert
   
 5. Fill in the fields on the lines with the **Item No.**, **Unit of Measure Code**, and the agreed **Unit Price**. You can also show the **Variant Code** column and specify the **Variant Code** if there are several variants of the item.  
   
-6. If the customer group needs to purchase a minimum quantity in order to gain the price agreed on, fill in the **Minimum Quantity** field.  
+6. If the customer group needs to purchase a minimum quantity to gain the price agreed on, fill in the **Minimum Quantity** field.  
 
 7. If required, enter the **Starting Date** and **Ending Date** of the price agreement.  
   

--- a/business-central/service-setup-service.md
+++ b/business-central/service-setup-service.md
@@ -30,7 +30,7 @@ The following table describes a sequence of tasks, with links to the articles th
 | Provide troubleshooting guidelines that help service reps deliver faster service. | [Set Up Troubleshooting](service-how-setup-troubleshooting.md) |
 | Set up resource allocation to make it easy to assign the right resource to a service task. | [Set Up Resource Allocation](service-how-setup-resource-allocation.md) |
 | Define pricing for services, and set up additional service costs to assess on service orders. | [Set Up Pricing and Additional Costs for Services](service-how-setup-service-costs-pricing.md) |
-| Set up things so you can track resource hours and service order status in order to forecast workloads and service needs. | [Set Up Work Hours and Service Hours](service-how-setup-work-service-hours.md) |
+| Set up things so you can track resource hours and service order status to forecast workloads and service needs. | [Set Up Work Hours and Service Hours](service-how-setup-work-service-hours.md) |
 | Set up repair status options so that you can monitor progress on repairs. | [Set Up Statuses for Service Orders and Repairs](service-order-repair-status.md) |
 | Set up a loaner program, so you can lend a substitute while you work on a service item. | [Set Up a Loaner Program](service-how-setup-loaner-program.md) |
 | Set up service items and service item components. | [Set Up Service Items](service-how-setup-service-items.md) |


### PR DESCRIPTION
Three docs use "in order to" where plain "to" is more concise, per Microsoft Writing Style Guide.

Changes:
- `sales-how-to-set-up-customer-discount-groups.md` L24: "in order to gain the discount" to "to gain the discount"
- `sales-how-to-set-up-customer-price-groups.md` L39: "in order to gain the price agreed on" to "to gain the price agreed on"
- `service-setup-service.md` L33: "in order to forecast workloads" to "to forecast workloads"
