### PR TITLE
Explain why item variants aren't used in usage-based billing

### DIFF
--- a/business-central/UBB/masterdata/references.md
+++ b/business-central/UBB/masterdata/references.md
@@ -42,6 +42,8 @@ The reference displays on the **Usage Data Supplier References** page as type **
 > [!NOTE]
 > For each item, you can enter a separate product reference per [Usage data suppliers](suppliers.md). [!INCLUDE [prod_short](../../includes/prod_short.md)] uses the reference to suggest the appropriate item as part of the [Extend contract](../processing-usage-data/extend-contract.md) functionality. If the product references aren't stored in the item master data, you can also select the corresponding item manually.
 
+Product references are matched at the item level, not per item variant. Usage data suppliers typically publish a separate item for each subscription plan or tier instead of modeling them as variants of one item, for example because of differences in contract term or pricing. For this reason, item variants aren't used when matching or creating subscription lines from usage data. To learn more, go to [Extend a contract](../processing-usage-data/extend-contract.md).
+
 ## References for customers
 
 A list of customers for which usage data is imported and processed can be created automatically. However, this is optional. Each customer or their ID has an entry on the **Usage Data Supplier References** page. When you have usage data customers, the record is also created automatically. Otherwise, you must create the reference manually. To learn more, go to [Usage data customers and suppliers](customers-subscriptions.md#usage-data-customers-and-suppliers).

--- a/business-central/UBB/processing-usage-data/extend-contract.md
+++ b/business-central/UBB/processing-usage-data/extend-contract.md
@@ -21,6 +21,9 @@ In addition to the **Customer Subscription Contract** page, the **Extend Contrac
 
 The **Subscription** field is available on the **Extend Contract** page on the **Vendor** FastTab. When you open the page from the **Usage Data Supp. Subscriptions** or **Imported Lines** pages, the subscription is automatically predefined. When you open the page from the menu, you can also select the (supplier) subscription using the AssistEdit :::image type="content" source="../../media/assist-edit-icon.png" alt-text="AssistEdit icon."::: button. The **Quantity** and **Provision Start Date** fields are predefined based on the (supplier) subscription. The item is also preselected if it was found through [references for products](../masterdata/references.md#references-for-products). If not, you can select it manually.
 
+> [!NOTE]
+> You can't select an item variant when extending a contract based on usage data, because usage data suppliers typically publish a separate item for each subscription plan or tier rather than modeling them as item variants. To learn more, go to [References for products](../masterdata/references.md#references-for-products).
+
 If you extend a contract, the created subscription lines automatically have a link to the [references for subscriptions](../masterdata/references.md#references-for-subscriptions), based on which the future usage data can be found and processed.
 
 ## Related information


### PR DESCRIPTION
## Summary
- Add an explanatory note to references.md clarifying that product references match at the item level, since usage data suppliers typically publish a separate item per subscription plan/tier instead of modeling them as item variants
- Cross-link from extend-contract.md, where the Variant Code field isn't available when extending a contract based on usage data