### PR TITLE
Document currency conversion for usage-based billing

### DIFF
--- a/business-central/SRB/setup/contract-types.md
+++ b/business-central/SRB/setup/contract-types.md
@@ -28,6 +28,10 @@ The **Harmonized Billing Customer Subscription Contracts** field controls whethe
 
 Use the **Create Contract Deferrals** field to define the default value for the corresponding field in the contract. This makes it easier to create contracts and reduces handling errors. When you select the contract type, the value is copied to the field in the contract. You can change the value manually, if needed. Besides this, a corresponding field in **Subscription Contract Setup** page exists.
 
+## Different currencies for usage data
+
+Use the **Allow Different Currency in Vendor Usage Data** and **Allow Different Currency in Customer Usage Data** fields to control what happens when the currency of imported usage data doesn't match the currency of the vendor or customer subscription contract. If you turn on the field, amounts are automatically converted to the contract's currency when usage data billing is created. If you turn off the field, an error is raised instead whenever the usage data's currency differs from the contract's currency. To learn more about usage data, go to [Import data in usage-based billing](../../UBB/processing-usage-data/imports-processing.md).
+
 ## Related information
 
 [General setup](general.md)  

--- a/business-central/UBB/processing-usage-data/imports-processing.md
+++ b/business-central/UBB/processing-usage-data/imports-processing.md
@@ -173,6 +173,9 @@ If there isn't a connection between a supplier's subscription and a subscription
 
 3. Usage data is typically supplier-side, which means it's probably missing the data you need for customer-side billing. You create the data for customers (records where the **Partner** field contains **Customer**) for each vendor usage data record when you generate the **Usage Data Billing** (via **Create Usage Data Billing** action) to use later for customer-side billing. You can use the lookup in the **No. of Usage Data Billing** field to access the details.
 
+> [!NOTE]
+> If the usage data's currency differs from the vendor or customer subscription contract's currency, amounts are either converted to the contract's currency or rejected with a processing error, depending on the subscription contract type. To learn more, go to [Subscription contract types](../../SRB/setup/contract-types.md#different-currencies-for-usage-data).
+
 Records in usage-based billing are vendor neutral, meaning all usage data is normalized regardless of the original source.
 
 4. By processing usage data billing (via **Process Usage Data Billing** action), the data in the respective vendor or customer subscription contract lines, in the subscriptions, and in the subscription lines are updated based on the new usage data (quantities and prices). In addition, the sales price is calculated for each data record where the **Partner** field contains **Customer**. To learn more, go to [Methods for pricing](#methods-for-pricing). If you get an error, use the lookup in the **No. of Usage Data Billing Errors** field to access the details.


### PR DESCRIPTION
## Summary
- Add a section to contract-types.md explaining the Allow Different Currency in Vendor/Customer Usage Data fields: when enabled, usage data amounts are converted to the contract currency; when disabled, a currency mismatch raises a processing error
- Cross-link from imports-processing.md at the Create Usage Data Billing step, where this check actually runs