### PR TITLE
Document rebilling usage data

### DIFF
--- a/business-central/TOC.md
+++ b/business-central/TOC.md
@@ -719,6 +719,7 @@ ms.service: dynamics-365-business-central
 #### Bill subscriptions based on usage
 ##### [Overview of usage-based billing](UBB/welcome.md)
 ##### [Import and process usage data](UBB/processing-usage-data/imports-processing.md) 
+##### [Rebilling usage data](UBB/processing-usage-data/rebilling.md)
 ##### [Use data exchange definitions to record usage](UBB/masterdata/dataexchangedefinitions.md)
 ##### [Manage usage data suppliers](UBB/masterdata/suppliers.md)
 ##### [Manage usage data supplier references](UBB/masterdata/references.md)

--- a/business-central/UBB/processing-usage-data/imports-processing.md
+++ b/business-central/UBB/processing-usage-data/imports-processing.md
@@ -198,5 +198,6 @@ The **Usage Data Billing Metadata** page contains the data that serves as the ba
 ## Related information
 
 [Linking supplier subscriptions with subscriptions](connect-subscription-service-object.md)  
+[Rebilling usage data](rebilling.md)  
 [Usage-based billing customers and subscriptions](../masterdata/customers-subscriptions.md)  
 [Extension of subscription lines](../masterdata/service-commitments.md)  

--- a/business-central/UBB/processing-usage-data/rebilling.md
+++ b/business-central/UBB/processing-usage-data/rebilling.md
@@ -1,0 +1,44 @@
+---
+title: Rebilling usage data
+description: Business Central automatically rebills usage data that arrives for an already-invoiced period.
+author: brentholtorf
+ms.author: bholtorf
+ms.reviewer: bholtorf
+ms.topic: article
+ms.search.keywords: 
+ms.search.form: 8096
+ms.date: 08/13/2026
+ms.service: dynamics-365-business-central
+---
+# Rebilling usage data
+
+Usage-based billing normally expects new usage data to belong to a period that hasn't been invoiced yet. But some contracts are billed further in advance than usage data is reported. For example, an annual subscription is often invoiced for the entire year up front. If the subscription quantity is later increased during the year, and no usage data was provided before that point, the increase is only reported the next time usage data is delivered — for a period that [!INCLUDE [prod_short](../../includes/prod_short.md)] already invoiced.
+
+Normally, a subscription line that's already invoiced for its current period isn't considered for invoicing again until its next billing date — which, for an annual subscription, could be almost a year away. Rebilling is what makes sure this doesn't happen: it recognizes that the new usage data belongs to a period that was already invoiced, and makes the subscription line eligible for invoicing again, so the increase can be billed as a delta for the remainder of the period that's already been paid for.
+
+There's no setting to turn rebilling on or off. It's determined automatically: whenever new usage data covers the same billing period (the same charge end date) as a subscription line that's already been invoiced, [!INCLUDE [prod_short](../../includes/prod_short.md)] treats it as a rebilling correction rather than as new, regular usage.
+
+## What happens when data is rebilled
+
+When usage data is identified as a rebilling correction, several things happen automatically:
+
+* The corrected quantity is added on top of the subscription's existing quantity, instead of replacing it. This way, a correction adjusts the previously billed amount rather than overwriting it.
+* The subscription line's next billing date temporarily moves back to the start of the corrected period, so the correction is picked up the next time invoices are created. Once the correction is invoiced, the next billing date automatically moves forward again to the correct date.
+* The correction is calculated using only its own quantity, so it doesn't get blended with a later, regular billing period for the same subscription line.
+* A rebilling correction always ends up on its own invoice or credit memo line. It's never combined with a regular charge for the same subscription line, even if both are due in the same billing run. If you cancel a rebilling correction before it's invoiced (for example, by deleting the usage data), the next billing date is automatically restored to where it was before.
+
+## Review rebilling data
+
+To see whether a usage data billing line is a rebilling correction, and whether it's already been invoiced, use the **Usage Data Metadata** action. It's available from:
+
+* The **Usage Data Billings** page
+* The **Service Commitments** part of a subscription line
+* The customer and vendor subscription contract lines
+
+The action opens the **Usage Data Billing Metadata** page, which shows the **Rebilling** and **Invoiced** columns for the charge periods related to the subscription line.
+
+## Related information
+
+[Import data in usage-based billing](imports-processing.md)  
+[Extend a contract](extend-contract.md)  
+[Usage-based billing customers and subscriptions](../masterdata/customers-subscriptions.md)


### PR DESCRIPTION
## Summary
- Add a new article explaining rebilling: usage data that arrives for an already-invoiced period (e.g. a mid-year quantity increase on an annually prepaid subscription) is automatically treated as a delta correction instead of being merged into or lost against the next regular billing period
- Covers the automatic behavior (quantity as delta, next billing date rewind, separate invoice/credit memo line) and how to review it via the Usage Data Metadata action
- Register the article in TOC.md and cross-link it from imports-processing.md